### PR TITLE
Modify the way that ordering is stored

### DIFF
--- a/godelplugin/amalgomateplugin/config/config_test.go
+++ b/godelplugin/amalgomateplugin/config/config_test.go
@@ -23,10 +23,12 @@ amalgomators:
     output-dir: test-output
     pkg: test-pkg
   next-product:
+    order: 1
     config: next.yml
     output-dir: next-output
     pkg: next-pkg
   other-product:
+    order: 2
     config: other.yml
     output-dir: other-output
     pkg: other-pkg
@@ -43,11 +45,13 @@ amalgomators:
 				Pkg:       "test-pkg",
 			},
 			"next-product": {
+				Order:     1,
 				Config:    "next.yml",
 				OutputDir: "next-output",
 				Pkg:       "next-pkg",
 			},
 			"other-product": {
+				Order:     2,
 				Config:    "other.yml",
 				OutputDir: "other-output",
 				Pkg:       "other-pkg",
@@ -61,6 +65,7 @@ func TestToParam(t *testing.T) {
 	cfg := config.Config{
 		Amalgomators: config.ToAmalgomators(map[string]config.ProductConfig{
 			"test-product": {
+				Order:     -1,
 				Config:    "test.yml",
 				OutputDir: "test-output",
 				Pkg:       "test-pkg",
@@ -79,6 +84,11 @@ func TestToParam(t *testing.T) {
 	}
 
 	wantParam := amalgomateplugin.Param{
+		OrderedKeys: []string{
+			"test-product",
+			"next-product",
+			"other-product",
+		},
 		Amalgomators: map[string]amalgomateplugin.ProductParam{
 			"test-product": {
 				Config:    "test.yml",
@@ -97,7 +107,6 @@ func TestToParam(t *testing.T) {
 			},
 		},
 	}
-	param, err := cfg.ToParam()
-	require.NoError(t, err)
-	assert.Equal(t, wantParam, param)
+	gotParam := cfg.ToParam()
+	assert.Equal(t, wantParam, gotParam)
 }

--- a/godelplugin/amalgomateplugin/config/internal/legacy/config.go
+++ b/godelplugin/amalgomateplugin/config/internal/legacy/config.go
@@ -39,18 +39,18 @@ func UpgradeConfig(cfgBytes []byte) ([]byte, error) {
 		return nil, errors.Wrapf(err, "failed to unmarshal amalgomate-plugin legacy configuration as yaml.MapSlice")
 	}
 
-	var orderedKeys []string
+	keyToOrder := make(map[string]int)
 	amalgomators := configMapSlice[1].Value.(yaml.MapSlice)
-	for _, mapItem := range amalgomators {
-		orderedKeys = append(orderedKeys, mapItem.Key.(string))
+	for i, mapItem := range amalgomators {
+		keyToOrder[mapItem.Key.(string)] = i
 	}
 
 	v0Cfg := v0.Config{}
-	v0Cfg.OrderedKeys = orderedKeys
 	if len(legacyCfg.Amalgomators) > 0 {
 		v0Cfg.Amalgomators = make(map[string]v0.ProductConfig)
 		for k, v := range legacyCfg.Amalgomators {
 			v0Cfg.Amalgomators[k] = v0.ProductConfig{
+				Order:     keyToOrder[k],
 				Config:    v.Config,
 				OutputDir: v.OutputDir,
 				Pkg:       v.Pkg,

--- a/godelplugin/amalgomateplugin/config/internal/v0/config.go
+++ b/godelplugin/amalgomateplugin/config/internal/v0/config.go
@@ -10,14 +10,11 @@ import (
 )
 
 type Config struct {
-	// OrderedKeys stores the order in which the amalgomators should be run. If unspecified, they are run in
-	// alphabetical order based on the name of the key. If specified, every element must be present.
-	OrderedKeys []string `yaml:"ordered-keys,omitempty"`
-
 	Amalgomators map[string]ProductConfig `yaml:"amalgomators,omitempty"`
 }
 
 type ProductConfig struct {
+	Order     int    `yaml:"order,omitempty"`
 	Config    string `yaml:"config,omitempty"`
 	OutputDir string `yaml:"output-dir,omitempty"`
 	Pkg       string `yaml:"pkg,omitempty"`

--- a/godelplugin/cmd/run.go
+++ b/godelplugin/cmd/run.go
@@ -35,11 +35,7 @@ var runCmd = &cobra.Command{
 		if err := os.Chdir(projectDirFlag); err != nil {
 			return errors.Wrapf(err, "failed to set working directory")
 		}
-		param, err := cfg.ToParam()
-		if err != nil {
-			return err
-		}
-		return amalgomateplugin.Run(param, verifyFlag, cmd.OutOrStdout())
+		return amalgomateplugin.Run(cfg.ToParam(), verifyFlag, cmd.OutOrStdout())
 	},
 }
 

--- a/godelplugin/integration_test/integration_test.go
+++ b/godelplugin/integration_test/integration_test.go
@@ -43,16 +43,14 @@ amalgomators:
 				Legacy:     true,
 				WantOutput: "Upgraded configuration for amalgomate-plugin.yml\n",
 				WantFiles: map[string]string{
-					"godel/config/amalgomate-plugin.yml": `ordered-keys:
-- test-product
-- next-product
-- other-product
-amalgomators:
+					"godel/config/amalgomate-plugin.yml": `amalgomators:
   next-product:
+    order: 1
     config: next.yml
     output-dir: next-output
     pkg: next-pkg
   other-product:
+    order: 2
     config: other.yml
     output-dir: other-output
     pkg: other-pkg
@@ -66,21 +64,20 @@ amalgomators:
 			{
 				Name: "current config is unmodified",
 				ConfigFiles: map[string]string{
-					"godel/config/amalgomate-plugin.yml": `
-ordered-keys:
-  - test-product
-  - next-product
-  - other-product
-amalgomators:
+					"godel/config/amalgomate-plugin.yml": `amalgomators:
+  # comment
   test-product:
+    order: 0
     config: test.yml
     output-dir: test-output
     pkg: test-pkg
   next-product:
+    order: 1
     config: next.yml
     output-dir: next-output
     pkg: next-pkg
   other-product:
+    order: 2
     config: other.yml
     output-dir: other-output
     pkg: other-pkg
@@ -88,21 +85,20 @@ amalgomators:
 				},
 				WantOutput: "",
 				WantFiles: map[string]string{
-					"godel/config/amalgomate-plugin.yml": `
-ordered-keys:
-  - test-product
-  - next-product
-  - other-product
-amalgomators:
+					"godel/config/amalgomate-plugin.yml": `amalgomators:
+  # comment
   test-product:
+    order: 0
     config: test.yml
     output-dir: test-output
     pkg: test-pkg
   next-product:
+    order: 1
     config: next.yml
     output-dir: next-output
     pkg: next-pkg
   other-product:
+    order: 2
     config: other.yml
     output-dir: other-output
     pkg: other-pkg


### PR DESCRIPTION
Specify ordering using an "order" field in the configuration
(which defaults to 0) rather than depending on YAML map ordering.
If order values are the same, falls back to alphanumeric comparison.
Legacy configuration is upgraded preserving previous by-map-entry
ordering behavior.