### PR TITLE
Add -mod=readonly flag to go list call

### DIFF
--- a/amalgomate/modules.go
+++ b/amalgomate/modules.go
@@ -280,7 +280,7 @@ type GoModInfo struct {
 }
 
 func moduleInfoForDirectory(dir string) (*GoModInfo, error) {
-	goListCmd := exec.Command("go", "list", "-m", "-json")
+	goListCmd := exec.Command("go", "list", "-mod=readonly", "-m", "-json")
 	goListCmd.Dir = dir
 	output, err := goListCmd.CombinedOutput()
 	if err != nil {

--- a/changelog/@unreleased/pr-96.v2.yml
+++ b/changelog/@unreleased/pr-96.v2.yml
@@ -1,0 +1,8 @@
+type: fix
+fix:
+  description: |-
+    Fixes issue where "go list" could fail if performed in a module
+    inside a vendor directory that declared dependencies in its module
+    that did not match overall vendor directory.
+  links:
+  - https://github.com/palantir/amalgomate/pull/96


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fixes issue where "go list" could fail if performed in a module
inside a vendor directory that declared dependencies in its module
that did not match overall vendor directory.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

