### PR TITLE
Update amalgomate logic for Go 1.17

### DIFF
--- a/changelog/@unreleased/pr-112.v2.yml
+++ b/changelog/@unreleased/pr-112.v2.yml
@@ -1,0 +1,6 @@
+type: feature
+feature:
+  description: Updates implementation of code that performs module repackaging to
+    support vendored code that does not contain "go.mod" files (Go 1.17-style vendoring).
+  links:
+  - https://github.com/palantir/amalgomate/pull/112


### PR DESCRIPTION
## Before this PR
The current implementation of "amalgomate" only works for vendored packages if the vendored package contains a "go.mod" file. This was the behavior for vendored modules in Go 1.16 and earlier, but starting in Go 1.17, vendored dependencies no longer include a "go.mod" file, and attempting to perform amalgomation on Go 1.17-style vendoring results in an error of the form:

> Error: amalgomate failed for compiles: failed to repackage files specified in configuration: module for package github.com/palantir/go-compiles was reported as github.com/palantir/godel-okgo-asset-compiles, which is the same as the project module: it is likely that this package is not part of a real module, and repackaging non-modules is not supported

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Updates implementation of code that performs module repackaging to support vendored code that does not contain "go.mod" files (Go 1.17-style vendoring).
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

