### PR TITLE
Only call modulePathForDirectory for directories that contain Go files

### DIFF
--- a/changelog/@unreleased/pr-113.v2.yml
+++ b/changelog/@unreleased/pr-113.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: |-
+    Fixes issue where amalgomate would not properly copy modules that
+    contained subdirectories that did not contain any Go files.
+  links:
+  - https://github.com/palantir/amalgomate/pull/113


### PR DESCRIPTION
## Before this PR
If an amalgomation target module had a directory that did not contain any Go files (for example, the https://github.com/palantir/godel-okgo-asset-ineffassign/tree/master/vendor/github.com/gordonklaus/ineffassign/pkg directory in https://github.com/palantir/godel-okgo-asset-ineffassign), then that directory would be skipped entirely, which was an issue if it contained a subdirectory that contained Go files that was part of the module.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fixes issue where amalgomate would not properly copy modules that
contained subdirectories that did not contain any Go files.
==COMMIT_MSG==

## Possible downsides?
If a target module contain a deep directory tree that ends in a different module, this code will now create all the empty directories leading up to that. However, I don't think this is a major issue as empty directories are typically not tracked in CI.

An alternate approach that also works is to update the `modulePathForDirectory` function to be the following:

```go
func modulePathForDirectory(dir, baseDir string) (string, error) {
	var dirModule *packages.Module
	currDir := dir

	for dirModule == nil {
		dirPkg, err := packageForPatternInDirectory(currDir, currDir, packages.NeedModule)
		if err != nil {
			return "", errors.Wrapf(err, "failed to determine package for directory")
		}
		dirModule = dirPkg.Module

		if dirModule != nil {
			return dirPkg.Module.Path, nil
		}

		if currDir == baseDir {
			// got to root of source directory: fall back on moduleInfoForDirectory
			modInfo, err := moduleInfoForDirectory(dir)
			if err != nil {
				return "", errors.Wrapf(err, "failed to fall back on moduleInfoForDirectory")
			}
			return modInfo.Path, nil
		}

		// package lookup didn't work: this could be because directory does not contain any Go files and module could
		// not be determined. Try parent directory instead.
		currDir = filepath.Dir(currDir)
	}
	return "", errors.Errorf("unable to determine module for directory %s", dir)
}
```

This logic makes it such that, if the module for a directory can't be determined, the first parent directory whose module can be determined is used (and a base directory is provided to ensure that there is a stopping point).

This logic would eliminate the "empty directory" issue, but I think it makes the implementation of `modulePathForDirectory` harder to reason about, so opting for this approach first. If it turns out that the empty directory path creation is encountered and is an issue, we can evaluate changing the approach.

