### PR TITLE
Fix amalgomation issues with vendored code in Go 1.20

### DIFF
--- a/changelog/@unreleased/pr-187.v2.yml
+++ b/changelog/@unreleased/pr-187.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Fixes issue where program would crash if attempting to amalgomate vendored
+    modules using Go 1.20.
+  links:
+  - https://github.com/palantir/amalgomate/pull/187


### PR DESCRIPTION
Handle behavior changes to "go list" that were made in Go 1.20 that broke amalgomate.

Fixes #186

## Before this PR
Amalgomation would fail for vendored modules when running with Go 1.20.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fixes issue where program would crash if attempting to amalgomate vendored modules using Go 1.20.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

