### PR TITLE
Update so that original permissions are preserved

### DIFF
--- a/amalgomate/modules.go
+++ b/amalgomate/modules.go
@@ -139,9 +139,7 @@ func rewriteImports(repackagedModuleRootDir, moduleImportPath, importPathToRepac
 		}
 		fmtSrcDir := path.Join(goRoot, "src", "flag")
 		fmtDstDir := path.Join(repackagedModuleRootDir, "amalgomated_flag")
-		if err := copy.Copy(fmtSrcDir, fmtDstDir, copy.Options{
-			AddPermission: 0755,
-		}); err != nil {
+		if err := copy.Copy(fmtSrcDir, fmtDstDir); err != nil {
 			return errors.Wrapf(err, "failed to copy directory %s to %s", fmtSrcDir, fmtDstDir)
 		}
 		if _, err := removeEmptyDirs(fmtDstDir); err != nil {

--- a/changelog/@unreleased/pr-299.v2.yml
+++ b/changelog/@unreleased/pr-299.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: Make it such that amalgomated files are not all given 0755 permissions
+    -- instead, original permissions are preserved, but copying still works even if
+    original directory is not writable.
+  links:
+  - https://github.com/palantir/amalgomate/pull/299


### PR DESCRIPTION

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Make it such that amalgomated files are not all given 0755 permissions -- instead, original permissions are preserved, but copying still works even if original directory is not writable.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

