### PR TITLE
Update amalgomage directory creation logic

### DIFF
--- a/amalgomate/modules.go
+++ b/amalgomate/modules.go
@@ -139,7 +139,7 @@ func rewriteImports(repackagedModuleRootDir, moduleImportPath, importPathToRepac
 		}
 		fmtSrcDir := path.Join(goRoot, "src", "flag")
 		fmtDstDir := path.Join(repackagedModuleRootDir, "amalgomated_flag")
-		if err := copy.Copy(fmtSrcDir, fmtDstDir); err != nil {
+		if err := os.CopyFS(fmtDstDir, os.DirFS(fmtSrcDir)); err != nil {
 			return errors.Wrapf(err, "failed to copy directory %s to %s", fmtSrcDir, fmtDstDir)
 		}
 		if _, err := removeEmptyDirs(fmtDstDir); err != nil {

--- a/changelog/@unreleased/pr-300.v2.yml
+++ b/changelog/@unreleased/pr-300.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Ensures that directories created by amalgomate have 0777 permissions.
+  links:
+  - https://github.com/palantir/amalgomate/pull/300


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Ensures that directories created by amalgomate have 0777 permissions.
==COMMIT_MSG==

Uses "os.CopyFS" to copy amalgomated directories to ensure that copied files and directories use appropriate permissions.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

