### PR TITLE
Fix issue where amalgomation could fail if package had no Go files

### DIFF
--- a/amalgomate/modules.go
+++ b/amalgomate/modules.go
@@ -279,9 +279,6 @@ func moduleInfoForPackage(pkgName, dir string) (*GoModInfo, error) {
 	if err != nil {
 		return nil, err
 	}
-	if len(outputDirPkg.GoFiles) == 0 {
-		return nil, errors.Errorf("no Go files in package %s resolved from directory %s", pkgName, dir)
-	}
 
 	if outputDirPkg.Module == nil {
 		return nil, errors.Errorf("unable to determine module for package %s resolved from directory %s", pkgName, dir)
@@ -353,11 +350,7 @@ func moduleInfoForPackage(pkgName, dir string) (*GoModInfo, error) {
 	}
 
 	moduleDir := dirStruct.Dir
-	if moduleDir == "" {
-		if len(outputDirPkg.GoFiles) == 0 {
-			return nil, errors.Errorf("package %s does not contain any Go files", outputDirPkg.PkgPath)
-		}
-
+	if moduleDir == "" && len(outputDirPkg.GoFiles) > 0 {
 		goFilePath := outputDirPkg.GoFiles[0]
 		lastVendorIdx := strings.LastIndex(goFilePath, "/vendor/")
 		if lastVendorIdx == -1 {


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fixes an issue where processing a package that has no Go files visible to the current build configuration could cause a failure, even if that package would not be amalgomated.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

