### PR TITLE
Add option to specify files for which flag import should not be rewritten

### DIFF
--- a/amalgomate/config.go
+++ b/amalgomate/config.go
@@ -16,7 +16,8 @@ type Config struct {
 }
 
 type SrcPkg struct {
-	MainPkg string `yaml:"main"`
+	MainPkg                string   `yaml:"main"`
+	DoNotRewriteFlagImport []string `yaml:"do-not-rewrite-flag-import"`
 }
 
 func LoadConfig(configPath string) (Config, error) {

--- a/amalgomate/modules_test.go
+++ b/amalgomate/modules_test.go
@@ -232,6 +232,7 @@ func AmalgomatedMain()	{}
 				filepath.Join(tmpDir, "internal"),
 				"github.com/repackaged-module",
 				"github.com/test-project/internal",
+				nil,
 			)
 			require.NoError(t, err)
 

--- a/changelog/@unreleased/pr-334.v2.yml
+++ b/changelog/@unreleased/pr-334.v2.yml
@@ -1,0 +1,9 @@
+type: improvement
+improvement:
+  description: Adds the "do-not-rewrite-flag-import" option to configuration, which
+    allows specifying the relative paths to files for which the "flag" import should
+    not be rewritten to an amalgomated version. This is useful when amalgomating files
+    that may use the "flag" package to pass or interpret data structures (but not
+    for the flags on the program itself).
+  links:
+  - https://github.com/palantir/amalgomate/pull/334


### PR DESCRIPTION

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Adds the "do-not-rewrite-flag-import" option to configuration, which allows specifying the relative paths to files for which the "flag" import should not be rewritten to an amalgomated version. This is useful when amalgomating files that may use the "flag" package to pass or interpret data structures (but not for the flags on the program itself).
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
