### PR TITLE
Add support for amalgomating code that uses "embed" directive

### DIFF
--- a/amalgomate/modules.go
+++ b/amalgomate/modules.go
@@ -186,6 +186,56 @@ func rewriteImports(
 	return nil
 }
 
+// copyEmbedFilesForPackage loads the package at packageDir and copies all files referenced by go:embed directives
+// from srcDir to dstRootPath, maintaining relative paths and applying renameInternal transformations if specified.
+func copyEmbedFilesForPackage(packageDir, srcDir, dstRootPath string, renameInternal bool) error {
+	// Load the package at this directory to get embed file information
+	pkg, err := packageForPatternInDirectory(".", packageDir, packages.NeedName|packages.NeedFiles|packages.NeedEmbedFiles)
+	if err != nil {
+		return errors.Wrapf(err, "failed to load package at directory %s", packageDir)
+	}
+
+	// Copy all embed files for this package
+	for _, embedFile := range pkg.EmbedFiles {
+		// Make embed file path relative to the source directory
+		relEmbedPath, err := filepath.Rel(srcDir, embedFile)
+		if err != nil {
+			return errors.Wrapf(err, "failed to make embed file %s relative to %s", embedFile, srcDir)
+		}
+
+		// Apply renameInternal transformation to the embed file path
+		if renameInternal {
+			if relEmbedPath == "internal" {
+				relEmbedPath = "internal_"
+			} else {
+				relEmbedPath = strings.ReplaceAll(relEmbedPath, "/internal/", "/internal_/")
+				if after, ok := strings.CutPrefix(relEmbedPath, "internal/"); ok {
+					relEmbedPath = "internal_/" + after
+				}
+				if before, ok := strings.CutSuffix(relEmbedPath, "/internal"); ok {
+					relEmbedPath = before + "/internal_"
+				}
+			}
+		}
+
+		// Determine destination path for the embed file
+		dstEmbedPath := filepath.Join(dstRootPath, relEmbedPath)
+
+		// Create parent directory if it doesn't exist
+		dstEmbedDir := filepath.Dir(dstEmbedPath)
+		if err := os.MkdirAll(dstEmbedDir, 0755); err != nil {
+			return errors.Wrapf(err, "failed to create directory for embed file at %s", dstEmbedDir)
+		}
+
+		// Copy the embed file
+		if err := copy.Copy(embedFile, dstEmbedPath); err != nil {
+			return errors.Wrapf(err, "failed to copy embed file from %s to %s", embedFile, dstEmbedPath)
+		}
+	}
+
+	return nil
+}
+
 // copyModuleRecursively recursively copies the module with the canonical name modulePath from srcDir into dstDir. Only
 // copies files with the suffix ".go", omits files with the suffix "_test.go" and skips all directories named "vendor".
 // The contents of srcDir are copied into the directory path that consists of the module path converted into a file
@@ -260,6 +310,13 @@ func copyModuleRecursively(modulePath, srcDir, dstDir string, renameInternal boo
 				}
 				if currPathModulePath != modulePath {
 					return fs.SkipDir
+				}
+
+				// Copy any files referenced by go:embed directives in this package
+				if err := copyEmbedFilesForPackage(path, srcDir, dstRootPath, renameInternal); err != nil {
+					// TODO: log this error in the future instead of silently continuing
+					// For now, continue even if embed file copying fails to maintain backwards compatibility
+					_ = err
 				}
 			}
 		} else if !strings.HasSuffix(d.Name(), ".go") || strings.HasSuffix(d.Name(), "_test.go") {

--- a/amalgomate/modules_test.go
+++ b/amalgomate/modules_test.go
@@ -1245,6 +1245,267 @@ func Test_copyModuleRecursively(t *testing.T) {
 	}
 }
 
+// Test_copiesEmbedFiles verifies that copyModuleRecursively copies files referenced by go:embed directives.
+func Test_copiesEmbedFiles(t *testing.T) {
+	for _, tc := range []struct {
+		Name           string
+		ModuleName     string
+		SrcFiles       []gofiles.GoFileSpec
+		WantFiles      []string
+		RenameInternal bool
+	}{
+		{
+			Name:       "Copies embed files in root package",
+			ModuleName: "github.com/test",
+			SrcFiles: []gofiles.GoFileSpec{
+				{
+					RelPath: "go.mod",
+					Src:     "module github.com/test",
+				},
+				{
+					RelPath: "main.go",
+					Src: `package main
+
+import _ "embed"
+
+//go:embed data.txt
+var content string
+
+func main() {}
+`,
+				},
+				{
+					RelPath: "data.txt",
+					Src:     "test data content",
+				},
+			},
+			WantFiles: []string{
+				"github.com",
+				"github.com/test",
+				"github.com/test/data.txt",
+				"github.com/test/main.go",
+			},
+		},
+		{
+			Name:       "Copies multiple embed files",
+			ModuleName: "github.com/test",
+			SrcFiles: []gofiles.GoFileSpec{
+				{
+					RelPath: "go.mod",
+					Src:     "module github.com/test",
+				},
+				{
+					RelPath: "main.go",
+					Src: `package main
+
+import _ "embed"
+
+//go:embed file1.txt
+var content1 string
+
+//go:embed file2.txt
+var content2 string
+
+func main() {}
+`,
+				},
+				{
+					RelPath: "file1.txt",
+					Src:     "content 1",
+				},
+				{
+					RelPath: "file2.txt",
+					Src:     "content 2",
+				},
+			},
+			WantFiles: []string{
+				"github.com",
+				"github.com/test",
+				"github.com/test/file1.txt",
+				"github.com/test/file2.txt",
+				"github.com/test/main.go",
+			},
+		},
+		{
+			Name:       "Copies embed files with wildcard pattern",
+			ModuleName: "github.com/test",
+			SrcFiles: []gofiles.GoFileSpec{
+				{
+					RelPath: "go.mod",
+					Src:     "module github.com/test",
+				},
+				{
+					RelPath: "main.go",
+					Src: `package main
+
+import "embed"
+
+//go:embed *.txt
+var content embed.FS
+
+func main() {}
+`,
+				},
+				{
+					RelPath: "file1.txt",
+					Src:     "content 1",
+				},
+				{
+					RelPath: "file2.txt",
+					Src:     "content 2",
+				},
+			},
+			WantFiles: []string{
+				"github.com",
+				"github.com/test",
+				"github.com/test/file1.txt",
+				"github.com/test/file2.txt",
+				"github.com/test/main.go",
+			},
+		},
+		{
+			Name:       "Copies embed files in subdirectory",
+			ModuleName: "github.com/test",
+			SrcFiles: []gofiles.GoFileSpec{
+				{
+					RelPath: "go.mod",
+					Src:     "module github.com/test",
+				},
+				{
+					RelPath: "main.go",
+					Src:     "package main\n\nfunc main() {}",
+				},
+				{
+					RelPath: "pkg/handler.go",
+					Src: `package pkg
+
+import _ "embed"
+
+//go:embed config.json
+var config string
+`,
+				},
+				{
+					RelPath: "pkg/config.json",
+					Src:     `{"key": "value"}`,
+				},
+			},
+			WantFiles: []string{
+				"github.com",
+				"github.com/test",
+				"github.com/test/main.go",
+				"github.com/test/pkg",
+				"github.com/test/pkg/config.json",
+				"github.com/test/pkg/handler.go",
+			},
+		},
+		{
+			Name:       "Copies embed files with directory pattern",
+			ModuleName: "github.com/test",
+			SrcFiles: []gofiles.GoFileSpec{
+				{
+					RelPath: "go.mod",
+					Src:     "module github.com/test",
+				},
+				{
+					RelPath: "main.go",
+					Src: `package main
+
+import "embed"
+
+//go:embed assets
+var content embed.FS
+
+func main() {}
+`,
+				},
+				{
+					RelPath: "assets/style.css",
+					Src:     "body { }",
+				},
+				{
+					RelPath: "assets/script.js",
+					Src:     "console.log('test');",
+				},
+			},
+			WantFiles: []string{
+				"github.com",
+				"github.com/test",
+				"github.com/test/assets",
+				"github.com/test/assets/script.js",
+				"github.com/test/assets/style.css",
+				"github.com/test/main.go",
+			},
+		},
+		{
+			Name:           "Renames internal directory in embed file paths when renameInternal is true",
+			ModuleName:     "github.com/test",
+			RenameInternal: true,
+			SrcFiles: []gofiles.GoFileSpec{
+				{
+					RelPath: "go.mod",
+					Src:     "module github.com/test",
+				},
+				{
+					RelPath: "main.go",
+					Src:     "package main\n\nfunc main() {}",
+				},
+				{
+					RelPath: "internal/pkg/handler.go",
+					Src: `package pkg
+
+import _ "embed"
+
+//go:embed data.txt
+var content string
+`,
+				},
+				{
+					RelPath: "internal/pkg/data.txt",
+					Src:     "internal data",
+				},
+			},
+			WantFiles: []string{
+				"github.com",
+				"github.com/test",
+				"github.com/test/internal_",
+				"github.com/test/internal_/pkg",
+				"github.com/test/internal_/pkg/data.txt",
+				"github.com/test/internal_/pkg/handler.go",
+				"github.com/test/main.go",
+			},
+		},
+	} {
+		t.Run(tc.Name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+
+			dstDir := filepath.Join(tmpDir, "dstDir")
+			err := os.Mkdir(dstDir, 0755)
+			require.NoError(t, err)
+
+			srcDir := filepath.Join(tmpDir, "srcDir")
+			_, err = gofiles.Write(srcDir, tc.SrcFiles)
+			require.NoError(t, err)
+
+			// Run go mod tidy to ensure the module is properly set up
+			goModTidy := exec.Command("go", "mod", "tidy")
+			goModTidy.Dir = srcDir
+			err = goModTidy.Run()
+			require.NoError(t, err)
+
+			err = copyModuleRecursively(tc.ModuleName, srcDir, dstDir, tc.RenameInternal)
+			require.NoError(t, err)
+
+			gotFilePaths, err := allFilePaths(dstDir)
+			require.NoError(t, err)
+
+			sort.Strings(gotFilePaths)
+			sort.Strings(tc.WantFiles)
+			assert.Equal(t, tc.WantFiles, gotFilePaths)
+		})
+	}
+}
+
 func allFilePaths(dir string) ([]string, error) {
 	var paths []string
 	if err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {


### PR DESCRIPTION

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Ensure that paths that are referenced in the "embed" directive of amalgomated code is copied/amalgomated along with the source code.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

